### PR TITLE
feat(workflows): Auto-generate sbom

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,6 @@ jobs:
         uses: nais/docker-build-push@v0
         id: docker-build-push
         with:
-          byosbom: dependency-graph-reports/build_and_deploy-build.json
           team: okonomi
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}


### PR DESCRIPTION
Det er mulig å sende med egen sbom, men då må formatet vare CycloneDx, men github sitt eget format er ikke støttet i backend. Ved å fjerne input for egen sbom så vill det genereres en automagsikt, men det kan då legges på lit tid på deploy beroende på størrelse på prosjekt.

for å generere denne sbom i rett format så kan man sjekk i nais doc: https://docs.nais.io/security/salsa/?h=#known-limitations-and-alternatives