### PR TITLE
Add manual netty-handler resolution to 4.2.15.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,6 +102,12 @@ configurations.all {
                     "CVE-2026-42587: Netty HttpContentDecompressor maxAllocation bypass with br/zstd/snappy leads to decompression bomb DoS. Affected version = 4.2.11.Final, patched in >= 4.2.13.Final",
                 )
             }
+            if (requested.group == "io.netty" && requested.name == "netty-handler") {
+                useVersion("4.2.15.Final")
+                because(
+                    "CVE-2026-44249 and CVE-2026-45416: enforce patched netty-handler version in production runtime classpath",
+                )
+            }
             if (requested.group == "io.netty" && requested.name == "netty-transport-native-epoll") {
                 useVersion("4.2.13.Final")
                 because(


### PR DESCRIPTION
## Scope
- Operating mode: manual resolution-strategy mode
- Change scope: production dependency resolution in `build.gradle.kts` only
- Applied version exactly as requested: `io.netty:netty-handler:4.2.15.Final`
- CVEs addressed by this rule: `CVE-2026-44249`, `CVE-2026-45416`
- Existing resolution rules were reviewed against production runtime graph; no duplicate or stale active rules were found to consolidate/remove in this file
- All changes are consolidated into one pull request

## Summary
- Added one `resolutionStrategy.eachDependency` rule for `io.netty:netty-handler`
- Verified resolved production graph now selects `io.netty:netty-handler:4.2.15.Final`
- Kept existing active rules unchanged because they are still effective and non-duplicative
- Changed file: `build.gradle.kts`

## Dependency verification
- `./gradlew --no-daemon dependencies --configuration runtimeClasspath`
- `./gradlew --no-daemon dependencyInsight --dependency netty-handler --configuration runtimeClasspath`
- `./gradlew --no-daemon dependencyInsight --dependency netty-handler --configuration compileClasspath`
- Additional active-rule verification was run with `dependencyInsight` for the other existing overridden modules in `runtimeClasspath`

## Validation
- `./gradlew --no-daemon test check build` ✅
